### PR TITLE
Forgot to add the selenium-standalone-server to the drivers array

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports.download = function(drivers, cb) {
   var defDrivers = remoteLibs.platform[platform] || []
 
   // download all files and then start the process
-  async.each(defDrivers.concat(drivers)
+  async.each(defDrivers.concat([remoteLibs.selenium], drivers)
               , download
               , function(e) {
                   if (e) return cb(e)


### PR DESCRIPTION
Builds still sometimes fail due to a race, because the selenium-standalone-server wasn't being downloaded beforehand. This adds that in to the array of drivers to download.