### PR TITLE
Removes the option of using phantomjs. It's deprecated.

### DIFF
--- a/libs/run.js
+++ b/libs/run.js
@@ -28,7 +28,6 @@ function run(op, cb) {
       javaArgs = javaArgs.concat(op.drivers.map(function(i) {
         return '-Dwebdriver.'+i.name+'.driver='+i.file
       }))
-      javaArgs.push('-Dphantomjs.binary.path='+require('phantomjs-prebuilt').path)
     }
 
     // base arguments

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "selenium-please",
   "description": "A library to download and launch the Selenium Server.",
-  "version": "0.2.19",
+  "version": "0.3.0",
   "homepage": "https://github.com/seebees/selenium-please",
   "author": "seebees@gmail.com",
   "main": "index.js",
@@ -12,7 +12,6 @@
   "keywords": [
     "selenium",
     "launcher",
-    "phantomjs",
     "chrome",
     "testing",
     "webdriver"
@@ -23,7 +22,6 @@
     "hash_file": "0.0.x",
     "lockfile": "^1.0.1",
     "nopt": "~3.0.1",
-    "phantomjs-prebuilt": "^2.1.13",
     "progress": "^1.1.8",
     "request": "2.9.x",
     "tar": "^2.2.1",

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ A library to download and launch the Selenium Server.
 This is clearly a copy of selenium-launcher, so credit where credit is due.
 All the awesome is there, all the bugs are mine.
 
-The idea is to get a Selenium server with browsers already installed.  It is a pain to download and maintain the right versions and options for each of the browers.  So this should just work.  Currently Chrome, Firefox, Internet Explorer, PhantomJS should just work.  Adding additional drivers to to the option hash should make these new browsers available.  Pull Requests to update remoteLibs.js are welcome.
+The idea is to get a Selenium server with browsers already installed.  It is a pain to download and maintain the right versions and options for each of the browers.  So this should just work.  Currently Chrome, Firefox, and Internet Explorer should just work.  Adding additional drivers to to the option hash should make these new browsers available.  Pull Requests to update remoteLibs.js are welcome.
 
 The most basic use case
 ---


### PR DESCRIPTION
Chrome (and headless Chrome) is already supported and is a better option
for browser tests.

Bumped semver to hopefully prevent accidental breakage of BC for other users.